### PR TITLE
Router & Service Wrapper

### DIFF
--- a/ai/ai-layer/.env.example
+++ b/ai/ai-layer/.env.example
@@ -1,0 +1,8 @@
+# Free-tier providers (all optional — missing keys are skipped silently)
+GOOGLE_API_KEY=
+MISTRAL_API_KEY=
+CEREBRAS_API_KEY=
+GROQ_API_KEY=
+
+# Commercial fallback (used only when all free providers are exhausted)
+ANTHROPIC_API_KEY=

--- a/ai/ai-layer/.gitignore
+++ b/ai/ai-layer/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/ai/ai-layer/README.md
+++ b/ai/ai-layer/README.md
@@ -1,0 +1,93 @@
+# ai-layer
+
+LLM router for MDDOAI. Exposes a FastAPI service that agents and the chat-ui call. Free providers are tried first in priority order; commercial Claude is the last resort.
+
+## Provider priority
+
+| Priority | Provider | Model |
+|---|---|---|
+| 1 | Google AI Studio | `gemini/gemini-2.5-flash` |
+| 2 | Mistral | `mistral/mistral-small-2506` |
+| 3 | Cerebras | `cerebras/gpt-oss-120b` |
+| 4 | Groq | `groq/llama-3.3-70b-versatile` |
+| 5 (commercial fallback) | Anthropic | `anthropic/claude-sonnet-4-6` |
+
+Providers with no API key set are skipped silently at startup.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+# Fill in at minimum ANTHROPIC_API_KEY, plus any free-tier keys you have
+```
+
+## Run
+
+```bash
+uvicorn main:app --reload
+```
+
+The service starts at [http://localhost:8000](http://localhost:8000).
+
+## API
+
+**GET /health** — liveness check.
+
+```bash
+curl http://localhost:8000/health
+# {"status":"ok"}
+```
+
+**POST /chat** — send a message and get a response.
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "Which CI/CD stages are needed?"}]}'
+# {"content": "...", "model": "gemini/gemini-2.5-flash"}
+```
+
+Request body: `{ "messages": [{"role": "user"|"assistant"|"system", "content": "..."}] }`
+
+Response: `{ "content": "...", "model": "provider/model-name" }`
+
+Every successful call also logs a JSON line to stdout:
+
+```json
+{"timestamp": "2026-06-19T14:32:01Z", "model": "gemini/gemini-2.5-flash", "tier": "free", "input_tokens": 120, "output_tokens": 38, "total_tokens": 158}
+```
+
+## Calling the router directly (Python)
+
+Agents can import `chat()` without going through HTTP:
+
+```python
+from router.router import chat
+
+response = chat(messages=[{"role": "user", "content": "Describe the pipeline stages."}])
+print(response.choices[0].message.content)
+```
+
+## Test
+
+```bash
+pytest
+```
+
+No real API calls are made — `litellm.completion` is mocked in tests.
+
+## Structure
+
+```
+ai-layer/
+  main.py             FastAPI app — /health and /chat endpoints
+  router/
+    config.py         provider list and priority order
+    logger.py         JSON stdout logging per call
+    router.py         chat() — builds the LiteLLM router, exposes one function
+  tests/
+    test_router.py    fallback behaviour tests
+  requirements.txt
+  .env.example
+```

--- a/ai/ai-layer/main.py
+++ b/ai/ai-layer/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from router.router import chat
+
+app = FastAPI(title="MDDOAI AI Layer")
+
+
+class ChatRequest(BaseModel):
+    messages: list[dict]
+
+
+class ChatResponse(BaseModel):
+    content: str
+    model: str
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/chat", response_model=ChatResponse)
+def chat_endpoint(request: ChatRequest):
+    try:
+        response = chat(request.messages)
+        return {"content": response.choices[0].message.content, "model": response.model}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/ai/ai-layer/pytest.ini
+++ b/ai/ai-layer/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/ai/ai-layer/requirements.txt
+++ b/ai/ai-layer/requirements.txt
@@ -1,0 +1,5 @@
+litellm==1.89.2
+python-dotenv>=1.0.0
+fastapi>=0.111.0
+uvicorn>=0.30.0
+pytest>=8.0.0

--- a/ai/ai-layer/router/config.py
+++ b/ai/ai-layer/router/config.py
@@ -1,0 +1,15 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Models are tried in priority order. Any provider with a missing API key is skipped.
+MODELS = [
+    {"name": "gemini-flash",  "model": "gemini/gemini-2.5-flash",      "key": os.getenv("GOOGLE_API_KEY"),    "tier": "free"},
+    {"name": "mistral-small", "model": "mistral/mistral-small-2506",   "key": os.getenv("MISTRAL_API_KEY"),   "tier": "free"},
+    {"name": "cerebras-120b", "model": "cerebras/gpt-oss-120b",        "key": os.getenv("CEREBRAS_API_KEY"),  "tier": "free"},
+    {"name": "groq-llama",    "model": "groq/llama-3.3-70b-versatile", "key": os.getenv("GROQ_API_KEY"),      "tier": "free"},
+    {"name": "claude",        "model": "anthropic/claude-sonnet-4-6",  "key": os.getenv("ANTHROPIC_API_KEY"), "tier": "commercial"},
+]
+
+AVAILABLE = [m for m in MODELS if m["key"]]

--- a/ai/ai-layer/router/logger.py
+++ b/ai/ai-layer/router/logger.py
@@ -1,0 +1,13 @@
+import json
+from datetime import datetime, timezone
+
+
+def log_call(model: str, tier: str, usage) -> None:
+    print(json.dumps({
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "model": model,
+        "tier": tier,
+        "input_tokens": getattr(usage, "prompt_tokens", 0),
+        "output_tokens": getattr(usage, "completion_tokens", 0),
+        "total_tokens": getattr(usage, "total_tokens", 0),
+    }), flush=True)

--- a/ai/ai-layer/router/router.py
+++ b/ai/ai-layer/router/router.py
@@ -1,0 +1,27 @@
+from litellm import Router
+from .config import AVAILABLE
+from .logger import log_call
+
+if not AVAILABLE:
+    raise RuntimeError("No API keys configured. Add at least one key to .env (see .env.example).")
+
+_names = [m["name"] for m in AVAILABLE]
+_tier  = {m["model"]: m["tier"] for m in AVAILABLE}
+
+# Build the LiteLLM router. Each provider falls back to the next on RateLimitError.
+_router = Router(
+    model_list=[
+        {"model_name": m["name"], "litellm_params": {"model": m["model"], "api_key": m["key"]}}
+        for m in AVAILABLE
+    ],
+    fallbacks=[{_names[i]: _names[i + 1:]} for i in range(len(_names) - 1)],
+    num_retries=0,
+)
+
+
+def chat(messages: list[dict], **kwargs):
+    """Call the LLM. Tries free providers first, falls back to commercial Claude if all fail."""
+    response = _router.completion(model=_names[0], messages=messages, **kwargs)
+    tier = _tier.get(response.model, "free")
+    log_call(response.model or _names[0], tier, response.usage)
+    return response

--- a/ai/ai-layer/tests/test_router.py
+++ b/ai/ai-layer/tests/test_router.py
@@ -1,0 +1,92 @@
+"""
+Router fallback tests. No real API calls — litellm.completion is mocked.
+
+Tests verify:
+  1. All free providers exhausted → commercial Claude is called.
+  2. Providers 1-3 fail → Groq handles it, commercial Claude is not called.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+from litellm import Router
+from litellm.exceptions import RateLimitError
+
+# Fake keys must be set before importing router modules so all five providers appear available.
+for key in ("GOOGLE_API_KEY", "MISTRAL_API_KEY", "CEREBRAS_API_KEY", "GROQ_API_KEY", "ANTHROPIC_API_KEY"):
+    os.environ.setdefault(key, f"test-{key.lower()}")
+
+from router.config import AVAILABLE  # noqa: E402
+
+
+def make_router():
+    names = [m["name"] for m in AVAILABLE]
+    router = Router(
+        model_list=[
+            {"model_name": m["name"], "litellm_params": {"model": m["model"], "api_key": m["key"]}}
+            for m in AVAILABLE
+        ],
+        fallbacks=[{names[i]: names[i + 1:]} for i in range(len(names) - 1)],
+        num_retries=0,
+    )
+    return router, names[0]
+
+
+def ok_response(model):
+    r = MagicMock()
+    r.model = model
+    r.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    r.choices = [MagicMock(message=MagicMock(content="ok"))]
+    return r
+
+
+def rate_limit(model):
+    return RateLimitError(
+        message="Rate limit exceeded",
+        model=model,
+        llm_provider="test",
+        response=MagicMock(status_code=429),
+    )
+
+
+def is_commercial(model):
+    return "claude" in model or "anthropic" in model
+
+
+def is_groq(model):
+    return "groq" in model or "llama" in model
+
+
+def test_all_free_exhausted_falls_back_to_commercial():
+    router, primary = make_router()
+    called = []
+
+    def side_effect(*args, **kwargs):
+        model = kwargs.get("model", "")
+        called.append(model)
+        if is_commercial(model):
+            return ok_response("anthropic/claude-sonnet-4-6")
+        raise rate_limit(model)
+
+    with patch("litellm.completion", side_effect=side_effect):
+        response = router.completion(model=primary, messages=[{"role": "user", "content": "hi"}])
+
+    assert is_commercial(response.model), f"Expected Claude, got {response.model}"
+    assert any(not is_commercial(m) for m in called), "No free provider was tried before falling back"
+
+
+def test_providers_1_to_3_fail_groq_handles_it():
+    router, primary = make_router()
+    called = []
+
+    def side_effect(*args, **kwargs):
+        model = kwargs.get("model", "")
+        called.append(model)
+        if is_groq(model):
+            return ok_response("groq/llama-3.3-70b-versatile")
+        raise rate_limit(model)
+
+    with patch("litellm.completion", side_effect=side_effect):
+        response = router.completion(model=primary, messages=[{"role": "user", "content": "hi"}])
+
+    assert is_groq(response.model), f"Expected Groq, got {response.model}"
+    assert not any(is_commercial(m) for m in called), "Commercial Claude should not have been called"


### PR DESCRIPTION
## Add LLM router and FastAPI service wrapper

Implements `ai/ai-layer/` - the Python service that sits between the chat UI and LLM providers.

**Router** (`router/`) - LiteLLM-backed with five providers in priority order: Gemini Flash, Mistral Small, Cerebras 120B, Groq Llama, and commercial Claude as last resort. Providers with no API key set are skipped at startup. On `RateLimitError`, the router automatically falls back to the next provider.

**API** (`main.py`) - FastAPI wrapper with `POST /chat` and `GET /health`. Thin layer over the router; agents can also import `chat()` directly without going through HTTP.

**Tests** - two pytest cases covering full free-provider exhaustion and partial fallback (providers 1–3 fail, Groq handles it, commercial not called). No real API calls made.

**Logging** - every successful call emits a JSON line to stdout with model name, tier (free/commercial), and token counts.
